### PR TITLE
Add swagger support for JWT

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,6 +30,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.5.0" />
     <PackageVersion Include="throw" Version="1.4.0" />
     <PackageVersion Include="xunit" Version="2.6.5" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.6" />

--- a/src/CleanArchitecture.Api/Controllers/ApiController.cs
+++ b/src/CleanArchitecture.Api/Controllers/ApiController.cs
@@ -14,9 +14,7 @@ public class ApiController : ControllerBase
     {
         return errors.Count is 0
             ? Problem()
-            : errors.All(error => error.Type == ErrorType.Validation)
-                ? ValidationProblem(errors)
-                : Problem(errors[0]);
+            : errors.All(error => error.Type == ErrorType.Validation) ? ValidationProblem(errors) : Problem(errors[0]);
     }
 
     private ObjectResult Problem(Error error)

--- a/src/CleanArchitecture.Api/Controllers/ApiController.cs
+++ b/src/CleanArchitecture.Api/Controllers/ApiController.cs
@@ -12,17 +12,11 @@ public class ApiController : ControllerBase
 {
     protected ActionResult Problem(List<Error> errors)
     {
-        if (errors.Count is 0)
-        {
-            return Problem();
-        }
-
-        if (errors.All(error => error.Type == ErrorType.Validation))
-        {
-            return ValidationProblem(errors);
-        }
-
-        return Problem(errors[0]);
+        return errors.Count is 0
+            ? Problem()
+            : errors.All(error => error.Type == ErrorType.Validation)
+                ? ValidationProblem(errors)
+                : Problem(errors[0]);
     }
 
     private ObjectResult Problem(Error error)

--- a/src/CleanArchitecture.Infrastructure/CleanArchitecture.Infrastructure.csproj
+++ b/src/CleanArchitecture.Infrastructure/CleanArchitecture.Infrastructure.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />

--- a/src/CleanArchitecture.Infrastructure/DependencyInjection.cs
+++ b/src/CleanArchitecture.Infrastructure/DependencyInjection.cs
@@ -8,6 +8,7 @@ using CleanArchitecture.Infrastructure.Reminders.Persistence;
 using CleanArchitecture.Infrastructure.Security;
 using CleanArchitecture.Infrastructure.Security.CurrentUserProvider;
 using CleanArchitecture.Infrastructure.Security.PolicyEnforcer;
+using CleanArchitecture.Infrastructure.Security.SwaggerSupport;
 using CleanArchitecture.Infrastructure.Security.TokenGenerator;
 using CleanArchitecture.Infrastructure.Security.TokenValidation;
 using CleanArchitecture.Infrastructure.Services;
@@ -103,6 +104,7 @@ public static class DependencyInjection
 
         services
             .ConfigureOptions<JwtBearerTokenValidationConfiguration>()
+            .ConfigureOptions<SwaggerJwtSupportConfiguration>()
             .AddAuthentication(defaultScheme: JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer();
 

--- a/src/CleanArchitecture.Infrastructure/Security/SwaggerSupport/SwaggerJwtSupportConfiguration.cs
+++ b/src/CleanArchitecture.Infrastructure/Security/SwaggerSupport/SwaggerJwtSupportConfiguration.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.OpenApi.Models;
+
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace CleanArchitecture.Infrastructure.Security.SwaggerSupport;
+
+public class SwaggerJwtSupportConfiguration : IConfigureOptions<SwaggerGenOptions>
+{
+    public void Configure(SwaggerGenOptions options)
+    {
+        options.AddSecurityDefinition("Bearer", new()
+        {
+            In = ParameterLocation.Header,
+            Description = "Please provide a valid jwt token.",
+            Name = "Authorization",
+            Type = SecuritySchemeType.Http,
+            BearerFormat = "JWT",
+            Scheme = "Bearer",
+        });
+
+        options.AddSecurityRequirement(new()
+        {
+            {
+                new()
+                {
+                    Reference = new()
+                    {
+                        Type = ReferenceType.SecurityScheme,
+                        Id = "Bearer",
+                    },
+                },
+                Array.Empty<string>()
+            },
+        });
+    }
+}


### PR DESCRIPTION
I thought being able to insert the token inside swagger would be a good idea.
I also tried to remove the token requirement only for the `GenerateToken` api, but I couldn't find a way to achieve this.
what do you think ? @amantinband 